### PR TITLE
misc: direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ build/
 
 ### Environment ###
 .env
+.direnv/
 
 ### Nix Artifacts ###
 result


### PR DESCRIPTION
Use `direnv` and `nix-direnv` to immediately step into a dev shell without the need to run `nix-develop`.